### PR TITLE
fix(styles): allow ui-select overflow

### DIFF
--- a/client/src/less/bhima-bootstrap.less
+++ b/client/src/less/bhima-bootstrap.less
@@ -287,3 +287,9 @@ input[type=number] {-moz-appearance: textfield;}
   box-shadow : 0px 2px 4px -4px black;
   z-index : 1000;
 }
+
+/* hack to get ui-selects to overflow over bootstrap's modals with */
+/* append-to-body="true" */
+body > .ui-select-bootstrap.open {
+  z-index: 1100;
+}

--- a/client/src/modules/stock/movements/modals/search.modal.html
+++ b/client/src/modules/stock/movements/modals/search.modal.html
@@ -11,7 +11,7 @@
     </ol>
   </div>
 
-  <div class="modal-body">
+  <div class="modal-body" style="padding:0;">
     <uib-tabset>
       <uib-tab index="0" heading="{{'FORM.LABELS.SEARCH_QUERRIES' | translate}}" data-custom-filter-tab>
         <div class="tab-body">
@@ -60,7 +60,7 @@
             <label class="control-label" translate>STOCK.FLUX</label>
             <bh-clear on-clear="$ctrl.clearFluxIds()"></bh-clear>
 
-            <ui-select multiple name="inventory" ng-model="$ctrl.selectedFluxes">
+            <ui-select multiple name="inventory" ng-model="$ctrl.selectedFluxes" append-to-body="true">
               <ui-select-match>
                 <span translate>{{$item.label}}</span>
               </ui-select-match>


### PR DESCRIPTION
This commit allows the `uiSelect` to overflow on top of a modal,
provided that "append-to-body" is given as _true_.  This fixes the
overflow issues in the stock modal.

For further information, see:
https://github.com/angular-ui/ui-select/wiki/FAQs#how-do-i-stop-the-drop-down-from-getting-cut-off-by-the-bottom-of-my-bootstrap-modal--container-with-overflow-hidden

![fixeduiselectmodaloverflow](https://user-images.githubusercontent.com/896472/30913864-8b50fc16-a389-11e7-9962-b1ad51d70674.png)
_Fig 1: The Fix._
